### PR TITLE
refactored worldstate with dry in mind

### DIFF
--- a/outputs/worldstate.go
+++ b/outputs/worldstate.go
@@ -20,78 +20,58 @@ func Everything(c *fiber.Ctx) error {
 
 // DarvoDeals DarvoDeals
 func DarvoDeals(c *fiber.Ctx) error {
-	platform := c.Params("platform")
-	token := c.Get("Accept-Language")
-	token1 := token[0:2]
-	token2 := token[0:5]
-	value, _ := intMap[platform]
-	messageJSON, _ := json.Marshal(parser.Darvodata[value][token1])
-	c.Type("json")
-	c.Set("Content-Language", token2)
-	return c.Send(messageJSON)
+	v, t1, t2 := getPlatformValueAndTokens(c)
+	messageJSON, _ := json.Marshal(parser.Darvodata[v][t1])
+	return sendJSONMessage(c, messageJSON, t2)
 }
 
 // News godoc
 func News(c *fiber.Ctx) error {
-	platform := c.Params("platform")
-	token := c.Get("Accept-Language")
-	value, _ := intMap[platform]
-	token1 := token[0:2]
-	token2 := token[0:5]
-	messageJSON, _ := json.Marshal(parser.Newsdata[value][token1])
-	c.Type("json")
-	c.Set("Content-Language", token2)
-	return c.Send(messageJSON)
+	v, t1, t2 := getPlatformValueAndTokens(c)
+	messageJSON, _ := json.Marshal(parser.Newsdata[v][t1])
+	return sendJSONMessage(c, messageJSON, t2)
 }
 
 // Alerts Alertsdata
 func Alerts(c *fiber.Ctx) error {
-	platform := c.Params("platform")
-	token := c.Get("Accept-Language")
-	value, _ := intMap[platform]
-	token1 := token[0:2]
-	token2 := token[0:5]
-	messageJSON, _ := json.Marshal(parser.Alertsdata[value][token1])
-	c.Type("json")
-	c.Set("Content-Language", token2)
-	return c.Send(messageJSON)
+	v, t1, t2 := getPlatformValueAndTokens(c)
+	messageJSON, _ := json.Marshal(parser.Alertsdata[v][t1])
+	return sendJSONMessage(c, messageJSON, t2)
 }
 
 // Fissures Fissuresdata
 func Fissures(c *fiber.Ctx) error {
-	platform := c.Params("platform")
-	token := c.Get("Accept-Language")
-	value, _ := intMap[platform]
-	token1 := token[0:2]
-	token2 := token[0:5]
-	messageJSON, _ := json.Marshal(parser.Fissuresdata[value][token1])
-	c.Type("json")
-	c.Set("Content-Language", token2)
-	return c.Send(messageJSON)
+	v, t1, t2 := getPlatformValueAndTokens(c)
+	messageJSON, _ := json.Marshal(parser.Fissuresdata[v][t1])
+	return sendJSONMessage(c, messageJSON, t2)
 }
 
 // Nightwave data
 func Nightwave(c *fiber.Ctx) error {
-	platform := c.Params("platform")
-	token := c.Get("Accept-Language")
-	value, _ := intMap[platform]
-	token1 := token[0:2]
-	token2 := token[0:5]
-	messageJSON, _ := json.Marshal(parser.Nightwavedata[value][token1])
-	c.Type("json")
-	c.Set("Content-Language", token2)
-	return c.Send(messageJSON)
+	v, t1, t2 := getPlatformValueAndTokens(c)
+	messageJSON, _ := json.Marshal(parser.Nightwavedata[v][t1])
+	return sendJSONMessage(c, messageJSON, t2)
 }
 
 // Penemy sdata
 func Penemy(c *fiber.Ctx) error {
+	v, t1, t2 := getPlatformValueAndTokens(c)
+	messageJSON, _ := json.Marshal(parser.Penemydata[v][t1])
+	return sendJSONMessage(c, messageJSON, t2)
+}
+
+func sendJSONMessage(c *fiber.Ctx, msg []byte, token2 string) error {
+	c.Type("json")
+	c.Set("Content-Language", token2)
+	return c.Send(msg)
+}
+
+func getPlatformValueAndTokens(c *fiber.Ctx) (int, string, string) {
 	platform := c.Params("platform")
 	token := c.Get("Accept-Language")
 	value, _ := intMap[platform]
 	token1 := token[0:2]
 	token2 := token[0:5]
-	messageJSON, _ := json.Marshal(parser.Penemydata[value][token1])
-	c.Type("json")
-	c.Set("Content-Language", token2)
-	return c.Send(messageJSON)
+
+	return value, token1, token2
 }


### PR DESCRIPTION
This PR refactors worldstate logic by abstracting out the repeated calls, to generate tokens and marshal json, into their own helper functions. Helps to make the code a bit more readable and maintainable since we now have one spot we'd need to update if we want to change how we send the json message or get the tokens (as opposed to 6 different spots within this file).